### PR TITLE
✨ feat(front) BS-1838: track max, cover, list with zefir

### DIFF
--- a/form.js
+++ b/form.js
@@ -1170,18 +1170,18 @@ $(document).ready(function () {
 });
 
 $(document).ready(function () {
-  const landingPageFocus = localStorage.getItem("landingPageFocus");
+  const productPitch = localStorage.getItem("productPitch");
 
-  if (!landingPageFocus) {
+  if (!productPitch) {
     return;
   }
 
   $("<input>")
     .attr({
       type: "hidden",
-      id: "landingPageFocus",
-      name: "landingPageFocus",
-      value: landingPageFocus,
+      id: "productPitch",
+      name: "productPitch",
+      value: productPitch,
     })
     .insertBefore("#form-page-validation");
 });

--- a/form.js
+++ b/form.js
@@ -1170,18 +1170,12 @@ $(document).ready(function () {
 });
 
 $(document).ready(function () {
-  const productPitch = localStorage.getItem("productPitch");
-
-  if (!productPitch) {
-    return;
-  }
-
   $("<input>")
     .attr({
       type: "hidden",
       id: "productPitch",
       name: "productPitch",
-      value: productPitch,
+      value: localStorage.getItem("productPitch") || "cover",
     })
     .insertBefore("#form-page-validation");
 });

--- a/landing.js
+++ b/landing.js
@@ -2,15 +2,23 @@ $(function () {
   initAutoComplete($("#autocomplete"), $("#goingnext"));
   initAutoComplete($("#autocomplete_2"), $("#goingnext-2"));
   initAutoComplete($("#autocomplete_3"), $("#goingnext-3"));
-  storeDataForLandingPageABTesting();
+  storeDataForProductPitchABTesting();
 });
 
-function storeDataForLandingPageABTesting() {
-  var landingPageFocus = { s: "certainty", v: "speed" }[
-    location.pathname.split("/")[1]
-  ];
-  if (landingPageFocus) {
-    localStorage.setItem("landingPageFocus", landingPageFocus);
+function storeDataForProductPitchABTesting() {
+  const path = location.pathname.toLowerCase();
+
+  // we use startsWith because subpaths might exist (`/lp/max/something` etc)
+  const productPitch = path.startsWith("/lp/max")
+    ? "max"
+    : path.startsWith("/lp/cover")
+    ? "cover"
+    : path.startsWith("/lp/list-with-zefir") //final URL will be defined in a future PR
+    ? "listing"
+    : "unknown";
+
+  if (productPitch) {
+    localStorage.setItem("productPitch", productPitch);
   }
 }
 

--- a/landing.js
+++ b/landing.js
@@ -8,18 +8,12 @@ $(function () {
 function storeDataForProductPitchABTesting() {
   const path = location.pathname.toLowerCase();
 
-  // we use startsWith because subpaths might exist (`/lp/max/something` etc)
-  const productPitch = path.startsWith("/lp/max")
-    ? "max"
-    : path.startsWith("/lp/cover")
-    ? "cover"
-    : path.startsWith("/lp/list-with-zefir") //final URL will be defined in a future PR
-    ? "listing"
-    : "unknown";
+  localStorage.setItem(
+    "productPitch",
 
-  if (productPitch) {
-    localStorage.setItem("productPitch", productPitch);
-  }
+    // we use startsWith because subpaths might exist (`/lp/max/something` etc)
+    path.startsWith("/lp/max") ? "max" : "cover"
+  );
 }
 
 let showError = true;


### PR DESCRIPTION
The goal of this PR is to track the product pitch through the app

This replaces the previous concept of "landing page focus",
-> the name, values and behavior are different

For the moment we only use max and [cover is the default value](https://teamzefir.slack.com/archives/C01G5T6A18F/p1670488910947729?thread_ts=1670342283.394599&cid=C01G5T6A18F)