### PR TITLE
impr: add search params propagation

### DIFF
--- a/search_params_propagation.js
+++ b/search_params_propagation.js
@@ -1,0 +1,27 @@
+$(function () {
+    function getCurrentQueryParams() {
+        const url = new URL(window.location.href);
+
+        return Object.fromEntries(url.searchParams.entries());
+    }
+
+    function appendUTMToLinks() {
+        const params = getCurrentQueryParams();
+        // If no keys are set, don't change links
+        if (Object.keys(params).length === 0) {
+            return;
+        }
+
+        document.querySelectorAll("a").forEach(link => {
+            const href = link.getAttribute("href");
+            if (href && href.startsWith("/") && !href.includes("#") && !href.includes("mailto:") && !href.includes("tel:")) {
+                const url = new URL(href, window.location.origin);
+
+                Object.keys(params).forEach((key) => url.searchParams.append(key, params[key]));
+                link.setAttribute("href", url.toString());
+            }
+        });
+    }
+
+    appendUTMToLinks();
+});


### PR DESCRIPTION
This pull request introduces a new feature in `search_params_propagation.js` to append UTM parameters to internal links on a webpage. The most important changes include the addition of functions to retrieve current query parameters and modify the links accordingly.

Enhancements to link handling:

* [`search_params_propagation.js`](diffhunk://#diff-c44f956999a2f0c1caa01ff56017d09cf62a72799fc7e84fecd82cecff1347a7R1-R27): Added a function `getCurrentQueryParams` to extract current URL query parameters and another function `appendUTMToLinks` to append these parameters to internal links, ensuring they propagate correctly.